### PR TITLE
Fix typo for emulator

### DIFF
--- a/main.go
+++ b/main.go
@@ -278,5 +278,5 @@ func main() {
 	if err := tools.ExportEnvironmentWithEnvman(bitriseEmulatorName, configs.Name); err != nil {
 		fail("Failed to export %s, error: %s", bitriseEmulatorName, err)
 	}
-	log.Donef("Emaultor name is exported in environment variable: %s (value: %s)", bitriseEmulatorName, configs.Name)
+	log.Donef("Emulator name is exported in environment variable: %s (value: %s)", bitriseEmulatorName, configs.Name)
 }


### PR DESCRIPTION
Noticed that when running the step it outputted the word Emulator with a typo in it so therefore I made a PR to fix it! :)

If there's anything else that I should include like updating a version or w/e please let me know. I'm more than happy to change it.